### PR TITLE
Fixes responses example typo "unprocessible"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ and the HTTP status codes can be replaced with their text equivalents:
 ```elixir
   @doc responses: [
     ok: {"User", "application/json", MyAppWeb.Schema.User}
-    unprocessible_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
+    unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
     not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
   ]
 ```


### PR DESCRIPTION
The current responses example has a typo in what should be `unprocessable_entity` (currently *unprocessible*), making it to not compile when trying to directly follow the example.

```
  @doc responses: [
    ok: {"User", "application/json", MyAppWeb.Schema.User}
    unprocessible_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
    not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
  ]